### PR TITLE
Fix deprecation warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,6 @@ from SublimeLinter.lint import Linter, util
 class Joker(Linter):
     """Provides an interface to joker."""
 
-    syntax = ['clojure', 'edn']
     executable = 'joker'
 
     def cmd(self):
@@ -37,9 +36,10 @@ class Joker(Linter):
     line_col_base = (1, 1)
     tempfile_suffix = None
     error_stream = util.STREAM_BOTH
-    selectors = {}
     word_re = r'^([-\w\.]+)'
-    defaults = {}
+    defaults = {
+        'selector': 'source.clj, source.cljs, source.edn'
+    }
     inline_settings = None
     inline_overrides = None
     comment_re = None

--- a/linter.py
+++ b/linter.py
@@ -16,8 +16,6 @@ from SublimeLinter.lint import Linter, util
 class Joker(Linter):
     """Provides an interface to joker."""
 
-    executable = 'joker'
-
     def cmd(self):
         """Return the command to run."""
         if self.filename.endswith('.joke'):
@@ -40,7 +38,4 @@ class Joker(Linter):
     defaults = {
         'selector': 'source.clj, source.cljs, source.edn'
     }
-    inline_settings = None
-    inline_overrides = None
-    comment_re = None
     on_stderr = None

--- a/linter.py
+++ b/linter.py
@@ -36,6 +36,6 @@ class Joker(Linter):
     error_stream = util.STREAM_BOTH
     word_re = r'^([-\w\.]+)'
     defaults = {
-        'selector': 'source.clj, source.cljs, source.edn'
+        'selector': 'source.clojure'
     }
     on_stderr = None


### PR DESCRIPTION
With the latest version of SublimeLinter (4.12.0), what were
deprecation warnings are now resulting in
SublimeLinter-contrib-joker being unable to run.

This commit resolves those deprecation warnings and returns
SublimeLinter-contrib-joker to working order as of SublimeLinter
version 4.12.0.